### PR TITLE
Fix build: replace useCopilotAction with useFrontendTool

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -215,7 +215,7 @@ export default function Page() {
   }, [hitlEnabled]);
 
   // Add new card — HITL mode (requires approval in chat)
-  useCopilotAction({
+  useFrontendTool({
     name: "addNewCardWithApproval",
     description: "Add new credit card (requires user approval)",
     disabled: !hitlEnabled || !PERMISSIONS.ADD_CARD.includes(currentUser.role),


### PR DESCRIPTION
## Summary
- `useCopilotAction` was renamed to `useFrontendTool` in the `@copilotkit/react-core` API
- Line 218 in `page.tsx` was missed during the rename, causing the Vercel build to fail with `Cannot find name 'useCopilotAction'`
- This is a one-line fix

## Test plan
- [ ] Verify Vercel build passes
- [ ] Confirm the "Add new card with approval" action still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)